### PR TITLE
css: Allow all tags

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -1,54 +1,5 @@
-const autoprefixer = require('autoprefixer');
-const purgecss = require('@fullhuman/postcss-purgecss');
-const whitelister = require('purgecss-whitelister');
+const autoprefixer = require('autoprefixer')
 
 module.exports = {
-  plugins: [
-    autoprefixer(),
-    purgecss({
-      content: [ './hugo_stats.json' ],
-      extractors: [
-        {
-          extractor: (content) => {
-            const els = JSON.parse(content).htmlElements;
-            return els.tags.concat(els.classes, els.ids);
-          },
-          extensions: ['json'],
-        },
-      ],
-      dynamicAttributes: [
-        'aria-expanded',
-        'data-bs-popper',
-        'data-bs-target',
-        'data-bs-theme',
-        'data-dark-mode',
-        'data-global-alert',
-        'data-pane',             // tabs.js
-        'data-popper-placement',
-        'data-sizes',
-        'data-toggle-tab',       // tabs.js
-        'id',
-        'size',
-        'type',
-      ],
-      safelist: [
-        'active',
-        'btn-clipboard',         // clipboards.js
-        'clipboard',             // clipboards.js
-        'disabled',
-        'hidden',
-        'modal-backdrop',        // search-modal.js
-        'selected',              // search-modal.js
-        'show',
-        'img-fluid',
-        'blur-up',
-        'lazyloaded',
-        ...whitelister([
-          './assets/scss/**/*.css',
-          './assets/scss/**/*.scss',
-          './node_modules/katex/dist/katex.css',
-        ]),
-      ],
-    }),
-  ],
+  plugins: [autoprefixer()]
 }


### PR DESCRIPTION
This is a workaround until we understand how to fix this. AFAIK, the purgecss component excludes tags from the generated css so the resulting website was missing some tags. It is now clear why this happens only when executed on GH actions and not locally.